### PR TITLE
Expose Edge container as \Pimple type

### DIFF
--- a/Edge/Core/Edge.php
+++ b/Edge/Core/Edge.php
@@ -43,6 +43,15 @@ class Edge implements \ArrayAccess{
     }
 
     /**
+     * return container
+     *
+     * @return \Pimple
+     */
+    public function getContainer(){
+        return $this->container;
+    }
+
+    /**
      * Get or set the current user
      * If no userID variable exists in the session
      * load the Guest user


### PR DESCRIPTION
In order to use [PhpStorm plugin](https://plugins.jetbrains.com/plugin/7809-silex-pimple-plugin) for code completion we container needs to be exposed as \Pimple type.